### PR TITLE
Added EIC External Interrupt Handling

### DIFF
--- a/src/mymodule.c
+++ b/src/mymodule.c
@@ -2,6 +2,7 @@
 #include "py/runtime.h"
 #include "samd/external_interrupts.h"
 #include "samd/pins.h"
+#include "hal/include/hal_gpio.h"
 
 
 #define SET_BIT(REG, BIT)     ((REG) |= (BIT))


### PR DESCRIPTION
- Added EIC External Interrupt (EXTINT) handling for D12/PA_19. The SAMD21 datasheet actually included some info on using the EIC/EXTINT for waking up from sleep (paragraph 21.6.8, page 310).

- Disabled PRIMASK instructions. The NVIC IRQs are not assigned by pins, but rather by peripherals (EIC, SysTick, USB, etc). If it still doesn't wake up, you can try using `NVIC_SetPriority(EIC_IRQn, 0)`


I didn't test this, since I'm not totally sure how you've set it up. If you powering from a computer with a data capable cable, I would expect that the USB will be unhappy after waking up (since CP may not wake up in a manner that re-establishes the CDC/MSC). File system may also be affected?

Let me know how it turns out. If you have any questions at all, don't hesitate to ask us. I am by no means an expert in this (still learning myself), and I have no shame in "elevating" any questions. :smile: